### PR TITLE
Fix credit positionn

### DIFF
--- a/src/credit.satyh
+++ b/src/credit.satyh
@@ -25,5 +25,5 @@ let-block ctx +credit =
     left-block ctx-items len {表紙画像加工} {\url(`http://williamngan.github.io/kubist/`);} +++
     left-block ctx-items len {表紙フォント} {鉄瓶ゴシック}
   in
-  clear-page +++ %% 必要なければ消す
-  block-skip 18cm +++ block-in ctx k
+  % clear-page +++ %% 必要なければ消す
+  block-skip 9cm +++ block-in ctx k


### PR DESCRIPTION
奥付だけのページのヘッダに章タイトルが出てきてしまっていて、パッと直すのが難しそうだったので、
奥付を youxkei さんの参考文献の下に置くことで章タイトルがヘッダにでてもOKという感じにします。